### PR TITLE
Use the full package name wagmi-magic-connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alexandria-labs/wagmi-connector",
+  "name": "@alexandria-labs/wagmi-magic-connector",
   "version": "2.1.1-alexandria.0",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "dist/index.js",


### PR DESCRIPTION
...that we used previously. This disambiguates that this is a wagmi connector for the Magic wallet.